### PR TITLE
Add Tables

### DIFF
--- a/build-libsql.ps1
+++ b/build-libsql.ps1
@@ -1,0 +1,1 @@
+go build -tags libsql

--- a/build-sqlite.ps1
+++ b/build-sqlite.ps1
@@ -1,0 +1,1 @@
+go build -tags sqlite

--- a/server/db/sqlite/migration/0003_password_libsql.go
+++ b/server/db/sqlite/migration/0003_password_libsql.go
@@ -1,0 +1,95 @@
+//go:build libsql
+// +build libsql
+
+package migration
+
+// Migration0003_DT_Passwords_And_Keys is a db migration script.
+// This migration adds the following tables:
+// - connection
+// - hash_public_key
+// - text_public_key
+// - private_key
+// The tables are used to store passwords and keys.
+// One can get the public key for a given hash or text.
+// Certain public keys can have their private key stored and shared.
+// Connections have their details stored in the connection table.
+var Migration0003_DT_Passwords_And_Keys = Migration{
+	Version: 3,
+	Name:    "DT: passwords & keys",
+	SQL: `
+CREATE TABLE IF NOT EXISTS connection(
+	id INTEGER NOT NULL PRIMARY KEY,
+	connection_id VARCHAR NOT NULL,
+	status varchar NOT NULL,
+	charm_id varchar,
+	target_id varchar,
+	app varchar NOT NULL,
+	type varchar NOT NULL,
+	name varchar NOT NULL,
+	description varchar NOT NULL,
+	username varchar NOT NULL,
+	password_length INTEGER NOT NULL,
+	password_hash varchar NOT NULL,
+	password_hash_type varchar NOT NULL,
+	public_key varchar NOT NULL,
+	interactive varchar NOT NULL,
+	pty varchar NOT NULL,
+	protocol varchar NOT NULL,
+	server_version varchar NOT NULL,
+	client_version varchar NOT NULL,
+	session_hash varchar NOT NULL,
+	permissions_critical_options varchar NOT NULL,
+	permissions_extensions varchar NOT NULL,
+	admin varchar NOT NULL,
+	query varchar NOT NULL,
+	host varchar NOT NULL,
+	port INTEGER NOT NULL,
+	commands varchar NOT NULL,
+	comments varchar NOT NULL,
+	history varchar NOT NULL,
+	remote_addr varchar NOT NULL,
+	remote_addr_network varchar NOT NULL,
+	opened_at timestamp default current_timestamp,
+	closed_at timestamp default current_timestamp,
+	created_at timestamp default current_timestamp,
+	updated_at timestamp default current_timestamp,
+	deleted_at timestamp
+) RANDOM ROWID;
+
+CREATE TABLE IF NOT EXISTS hash_public_key(
+  id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+  hash varchar NOT NULL,
+	hash_type varchar NOT NULL,
+  public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+) RANDOM ROWID;
+
+CREATE TABLE IF NOT EXISTS text_public_key(
+	id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+	text varchar NOT NULL,
+	text_type varchar NOT NULL,
+	public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+) RANDOM ROWID;
+
+CREATE TABLE IF NOT EXISTS private_key(
+	id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+	type varchar NOT NULL,
+	private_key varchar NOT NULL,
+	public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+) RANDOM ROWID;
+`,
+}

--- a/server/db/sqlite/migration/0003_password_sqlite.go
+++ b/server/db/sqlite/migration/0003_password_sqlite.go
@@ -1,0 +1,95 @@
+//go:build sqlite
+// +build sqlite
+
+package migration
+
+// Migration0003_DT_Passwords_And_Keys is a db migration script.
+// This migration adds the following tables:
+// - connection
+// - hash_public_key
+// - text_public_key
+// - private_key
+// The tables are used to store passwords and keys.
+// One can get the public key for a given hash or text.
+// Certain public keys can have their private key stored and shared.
+// Connections have their details stored in the connection table.
+var Migration0003_DT_Passwords_And_Keys = Migration{
+	Version: 3,
+	Name:    "DT: passwords & keys",
+	SQL: `
+CREATE TABLE IF NOT EXISTS connection(
+	id INTEGER NOT NULL PRIMARY KEY,
+	connection_id VARCHAR NOT NULL,
+	status varchar NOT NULL,
+	charm_id varchar,
+	target_id varchar,
+	app varchar NOT NULL,
+	type varchar NOT NULL,
+	name varchar NOT NULL,
+	description varchar NOT NULL,
+	username varchar NOT NULL,
+	password_length INTEGER NOT NULL,
+	password_hash varchar NOT NULL,
+	password_hash_type varchar NOT NULL,
+	public_key varchar NOT NULL,
+	interactive varchar NOT NULL,
+	pty varchar NOT NULL,
+	protocol varchar NOT NULL,
+	server_version varchar NOT NULL,
+	client_version varchar NOT NULL,
+	session_hash varchar NOT NULL,
+	permissions_critical_options varchar NOT NULL,
+	permissions_extensions varchar NOT NULL,
+	admin varchar NOT NULL,
+	query varchar NOT NULL,
+	host varchar NOT NULL,
+	port INTEGER NOT NULL,
+	commands varchar NOT NULL,
+	comments varchar NOT NULL,
+	history varchar NOT NULL,
+	remote_addr varchar NOT NULL,
+	remote_addr_network varchar NOT NULL,
+	opened_at timestamp default current_timestamp,
+	closed_at timestamp default current_timestamp,
+	created_at timestamp default current_timestamp,
+	updated_at timestamp default current_timestamp,
+	deleted_at timestamp
+);
+
+CREATE TABLE IF NOT EXISTS hash_public_key(
+  id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+  hash varchar NOT NULL,
+	hash_type varchar NOT NULL,
+  public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+);
+
+CREATE TABLE IF NOT EXISTS text_public_key(
+	id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+	text varchar NOT NULL,
+	text_type varchar NOT NULL,
+	public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+);
+
+CREATE TABLE IF NOT EXISTS private_key(
+	id INTEGER NOT NULL PRIMARY KEY,
+	charm_id varchar NOT NULL,
+	connection_id varchar NOT NULL,
+	type varchar NOT NULL,
+	private_key varchar NOT NULL,
+	public_key varchar NOT NULL,
+	created_at timestamp default current_timestamp,
+	update_at timestamp default current_timestamp,
+	delete_at timestamp
+);
+`,
+}

--- a/server/db/sqlite/migration/migration.go
+++ b/server/db/sqlite/migration/migration.go
@@ -7,6 +7,14 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+// Migrations is a list of all migrations.
+// The migrations must be in sequence starting from 1.
+var Migrations = []Migration{
+	Migration0001,
+	Migration0002,
+	Migration0003_DT_Passwords_And_Keys,
+}
+
 // Migration is a db migration script.
 type Migration struct {
 	Version int
@@ -47,11 +55,6 @@ func safeTime(t *time.Time) string {
 		return t.Format(time.RFC3339)
 	}
 	return "nil"
-}
-
-var Migrations = []Migration{
-	Migration0001,
-	Migration0002,
 }
 
 // Validate validates the migration sequence.

--- a/server/db/sqlite/migration/migration.go
+++ b/server/db/sqlite/migration/migration.go
@@ -12,7 +12,8 @@ import (
 var Migrations = []Migration{
 	Migration0001,
 	Migration0002,
-	Migration0003_DT_Passwords_And_Keys,
+	Migration0003_DT_Passwords_And_Keys, // <- 2 versions, choose one build tag: (libsql|sqlite)
+	// /\ main difference: libsql version uses RANDOM ROWID for create table statements
 }
 
 // Migration is a db migration script.

--- a/server/server.go
+++ b/server/server.go
@@ -34,7 +34,7 @@ type Config struct {
 	HealthPort     int    `env:"CHARM_SERVER_HEALTH_PORT" envDefault:"35356"`
 	DataDir        string `env:"CHARM_SERVER_DATA_DIR" envDefault:"data"`
 	DbDataSource   string `env:"CHARM_SERVER_DB_DATA_SOURCE" `
-	DbDriver       string `env:"CHARM_SERVER_DB_DRIVER" envDefault:"sqlite"`
+	DbDriver       string `env:"CHARM_SERVER_DB_DRIVER" envDefault:"libsql"`
 	UseTLS         bool   `env:"CHARM_SERVER_USE_TLS" envDefault:"false"`
 	TLSKeyFile     string `env:"CHARM_SERVER_TLS_KEY_FILE"`
 	TLSCertFile    string `env:"CHARM_SERVER_TLS_CERT_FILE"`


### PR DESCRIPTION
Sets different fork defaults, adds tables for migration 3, a DT migration. DT is still up-to-date with charm latest version 2.
|Charm|DT-Charm|DT|
|2|2|3|

```
Migration0003_DT_Passwords_And_Keys is a db migration script.
This migration adds the following tables:
- connection
- hash_public_key
- text_public_key
- private_key
The tables are used to store passwords and keys.
One can get the public key for a given hash or text.
Certain public keys can have their private key stored and shared.
Connections have their details stored in the connection table.
```